### PR TITLE
FWF-4805  WebAPI: Add a retry mechanism to verify process instance is initialized before sending message event payload

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
@@ -3701,6 +3701,27 @@ paths:
             application/json:
               schema:
                 type: object
+  /process-instance/{process_instance_id}/is-initialized:
+    parameters:
+      - name: process_instance_id
+        in: path
+        required: true
+        description: The unique id of an existing process instance.
+        schema:
+          type: string
+    get:
+      operationId: spiffworkflow_backend.routes.process_instances_controller.check_process_instance_status
+      summary: Checks whether a process is fully initialized
+      tags:
+        - Process Instances
+      
+      responses:
+        "200":
+          description: Process instance workflow initialization status
+          content:
+            application/json:
+              schema:
+                type: object
 components:
   securitySchemes:
     oAuth2AuthCode:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
@@ -6,7 +6,7 @@ from spiffworkflow_backend.helpers.spiff_enum import ProcessInstanceExecutionMod
 # ruff: noqa: I001
 
 import json
-from typing import Any
+from typing import Any, Dict
 import time
 
 import copy
@@ -748,3 +748,19 @@ def _process_instance_create(
         process_model_identifier, g.user
     )
     return process_instance
+
+
+def check_process_instance_status(process_instance_id: int):
+    """Checks if a process instance is fully initialized
+
+    Arguments:
+        process_instance_id {int} -- Unique ID of the process instance
+
+    Returns:
+        Dict -- {'status': <initialized or not>}
+    """
+    process_instance: ProcessInstanceModel = (
+        ProcessInstanceService().get_process_instance(process_instance_id)
+    )
+    is_initialized = process_instance.spiffworkflow_fully_initialized()
+    return make_response(jsonify({"status": is_initialized}), 200)


### PR DESCRIPTION
 - added new API to check if a process is initialized